### PR TITLE
Added support for fan speed controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@ Homebridge plugin for Leviton Decora Smart devices
 
 ## Supports
 These models are tested, though any other WiFi model should work.
-- DW6HD
-- DW1KD
-- DW3HL
-- DW15P
+- DW6HD 600W Dimmer
+- DW1KD 1000W Dimmer
+- DW3HL Wi-Fi Plugin Dimmer 
+- DW15P Wi-Fi Plugin Outlet
+- DW4SF Fan Speed Controller
 
 ## Setup
 - add `homebridge-leviton` in your Homebridge Config UI X web interface

--- a/index.js
+++ b/index.js
@@ -249,24 +249,88 @@ class LevitonDecoraSmartPlatform {
     const token = accessory.context.token
     
     //Get the model number
-    this.log('  -Device Model: ', device.model, device.customType)
+    this.log('  -Device Model: ', device.model)
     
     
-    switch (device.customType) {
-    	default:
-    		this.setupLightbulbService(accessory);
-    		break;
-    	case "ceiling-fan":
+    switch (device.model) {
+    	case "DW4SF":  //Fan Speed Control
 			this.setupFanService(accessory);
 	    	break;
-    		
-    
+    	case "DWVAA":  //Voice Dimmer with Amazon Alexa
+			this.setupLightbulbService(accessory);
+	    	break;
+       	case "DW1KD":  //1000W Dimmer
+			this.setupLightbulbService(accessory);
+	    	break;
+       	case "DW6HD":  //600W Dimmer
+			this.setupLightbulbService(accessory);
+	    	break;
+       	case "DW3HL":  //Plug-In Dimmer
+			this.setupLightbulbService(accessory);
+	    	break;
+	    	
+    	case "DW15R": //Tamper Resistant Outlet
+			this.setupOutletService(accessory);
+	    	break;
+    	case "DW15A": //Plug-in Outlet (1/2 HP)
+			this.setupOutletService(accessory);
+	    	break;
+    	case "DW15P": //Pluig-in Outlet (3/4 HP)
+			this.setupOutletService(accessory);
+	    	break;
+	    	
+    	default:  //Set up anything else as a simple switch (i.e. - DW15S, etc)
+    		this.setupSwitchService(accessory);
+    		break;
     }
       
   }
+ 
+  
+ async setupSwitchService(accessory){
+	  	this.log('  -Setting up device as Switch:', accessory.displayName);
+	  
+	  	// get device and token out of context to update status
+	    const device = accessory.context.device
+	    const token = accessory.context.token
+	    const status = await this.getStatus(device, token)
+
+	    // get the accessory service, if not add it
+	    const service =
+	      accessory.getService(Service.Switch, device.name) ||
+	      accessory.addService(Service.Switch, device.name);
+	    
+	    // add handlers for on/off characteristic, set initial value
+	    service
+	      .getCharacteristic(Characteristic.On)
+	      .on('get', this.onGetPower(service, device, token).bind(this))
+	      .on('set', this.onSetPower(service, device, token).bind(this))
+	      .updateValue(status.power === 'ON' ? true : false);
+}
+  
+ async setupOutletService(accessory){
+	  	this.log('  -Setting up device as Outlet:', accessory.displayName);
+	  
+	  	// get device and token out of context to update status
+	    const device = accessory.context.device
+	    const token = accessory.context.token
+	    const status = await this.getStatus(device, token)
+
+	    // get the accessory service, if not add it
+	    const service =
+	      accessory.getService(Service.Outlet, device.name) ||
+	      accessory.addService(Service.Outlet, device.name);
+	    
+	    // add handlers for on/off characteristic, set initial value
+	    service
+	      .getCharacteristic(Characteristic.On)
+	      .on('get', this.onGetPower(service, device, token).bind(this))
+	      .on('set', this.onSetPower(service, device, token).bind(this))
+	      .updateValue(status.power === 'ON' ? true : false);
+}
   
   async setupLightbulbService(accessory){
-	  	this.log('Setting up device as a Lightbulb:', accessory.displayName);
+	  	this.log('  -Setting up device as Lightbulb:', accessory.displayName);
 	  
 	  	// get device and token out of context to update status
 	    const device = accessory.context.device
@@ -296,12 +360,10 @@ class LevitonDecoraSmartPlatform {
 	        minStep: 1,
 	      })
 	      .updateValue(status.brightness);
-	      
-  }
-  
+  }  
   
   async setupFanService(accessory) {
-	  	this.log('Setting up device as a Fan:', accessory.displayName);
+	  	this.log('  -Setting up device as Fan:', accessory.displayName);
 
 	  	// get device and token out of context to update status
 	    const device = accessory.context.device
@@ -331,11 +393,7 @@ class LevitonDecoraSmartPlatform {
 	        minStep: status.minLevel,
 	      })
 	      .updateValue(status.brightness);
-	      this.log('Device Status:', status);
   }
-  
-  
-  
 
   // remove accessories and unregister
   removeAccessories() {

--- a/index.js
+++ b/index.js
@@ -254,40 +254,27 @@ class LevitonDecoraSmartPlatform {
     
     switch (device.model) {
     	case "DW4SF":  //Fan Speed Control
-			this.setupFanService(accessory);
+  			this.setupFanService(accessory);
 	    	break;
     	case "DWVAA":  //Voice Dimmer with Amazon Alexa
-			this.setupLightbulbService(accessory);
+      case "DW1KD":  //1000W Dimmer
+      case "DW6HD":  //600W Dimmer
+      case "DW3HL":  //Plug-In Dimmer
+			  this.setupLightbulbService(accessory);
 	    	break;
-       	case "DW1KD":  //1000W Dimmer
-			this.setupLightbulbService(accessory);
-	    	break;
-       	case "DW6HD":  //600W Dimmer
-			this.setupLightbulbService(accessory);
-	    	break;
-       	case "DW3HL":  //Plug-In Dimmer
-			this.setupLightbulbService(accessory);
-	    	break;
-	    	
     	case "DW15R": //Tamper Resistant Outlet
-			this.setupOutletService(accessory);
-	    	break;
     	case "DW15A": //Plug-in Outlet (1/2 HP)
-			this.setupOutletService(accessory);
-	    	break;
     	case "DW15P": //Pluig-in Outlet (3/4 HP)
-			this.setupOutletService(accessory);
-	    	break;
-	    	
+  			this.setupOutletService(accessory);
+	    	break;    	
     	default:  //Set up anything else as a simple switch (i.e. - DW15S, etc)
     		this.setupSwitchService(accessory);
     		break;
     }
       
   }
- 
   
- async setupSwitchService(accessory){
+  async setupSwitchService(accessory){
 	  	this.log('  -Setting up device as Switch:', accessory.displayName);
 	  
 	  	// get device and token out of context to update status
@@ -305,10 +292,10 @@ class LevitonDecoraSmartPlatform {
 	      .getCharacteristic(Characteristic.On)
 	      .on('get', this.onGetPower(service, device, token).bind(this))
 	      .on('set', this.onSetPower(service, device, token).bind(this))
-	      .updateValue(status.power === 'ON' ? true : false);
-}
+	      .updateValue(status.power === 'ON' ? true : false); 
+  }
   
- async setupOutletService(accessory){
+  async setupOutletService(accessory){
 	  	this.log('  -Setting up device as Outlet:', accessory.displayName);
 	  
 	  	// get device and token out of context to update status
@@ -327,7 +314,7 @@ class LevitonDecoraSmartPlatform {
 	      .on('get', this.onGetPower(service, device, token).bind(this))
 	      .on('set', this.onSetPower(service, device, token).bind(this))
 	      .updateValue(status.power === 'ON' ? true : false);
-}
+  }
   
   async setupLightbulbService(accessory){
 	  	this.log('  -Setting up device as Lightbulb:', accessory.displayName);


### PR DESCRIPTION
Added support for the DW4SF fan speed controller.  This is accomplished by reading the "customType" attribute on the device properties returned from the MyLeviton service.  I created separate functions to set up Lightbulb and Fan services and called the appropriate function via a switch statement. I did this in hopes of adding support for various different device types (switches, etc).  However, the only device I have to test on is the DW4SF.

I'm fairly new to JavaScript development so please excuse any bad coding.  Feel free to correct anything you see fit.

Thanks for writing this plugin!