### PR TITLE
Adds `D26HD` second-gen 600W dimmer

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,6 +256,7 @@ class LevitonDecoraSmartPlatform {
       case 'DWVAA': // Voice Dimmer with Amazon Alexa
       case 'DW1KD': // 1000W Dimmer
       case 'DW6HD': // 600W Dimmer
+      case 'D26HD': // 600W Dimmer (2nd Gen)
       case 'DW3HL': // Plug-In Dimmer
         this.setupLightbulbService(accessory)
         break


### PR DESCRIPTION
Resolves #13 

This PR adds the 600W 2nd generation dimmer switch. Let me know if you need tests or anything, I've been using my forked version for a few hours and it works great.