### PR TITLE
Fix issues with devices not fetching

### DIFF
--- a/api.js
+++ b/api.js
@@ -68,6 +68,16 @@ function getResidentialAccounts({ accountID, token }) {
   }).then((res) => res.json())
 }
 
+function getResidentialAccountsV2({ residenceObjectID, token }) {
+  return fetch(`${baseURL}/ResidentialAccounts/${residenceObjectID}/residences`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'X-Access-Token': token,
+    },
+  }).then((res) => res.json())
+}
+
 // obtain a user token to use in X-Access-Token header on all requests
 function postPersonLogin({ email, password }) {
   const query = toQueryString({
@@ -140,6 +150,7 @@ module.exports = {
   getPersonResidentialPermissions,
   getResidenceIotSwitches,
   getResidentialAccounts,
+  getResidentialAccountsV2,
   postPersonLogin,
   putIotSwitch,
   subscribe,

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ class LevitonDecoraSmartPlatform {
 
     try {
       if (!Array.isArray(devices) || devices.length < 1) {
-        console.log('No devices found for primary residence id. Trying residence v2')
+        this.log('No devices found for primary residence id. Trying residence v2')
         const accountsV2Response = await Leviton.getResidentialAccountsV2({
           residenceObjectID,
           token,
@@ -93,7 +93,9 @@ class LevitonDecoraSmartPlatform {
         })
 
         if (!Array.isArray(devices) || devices.length < 1) {
-          throw new Error(`No devices found for residenceID: ${residenceID} or residenceIDV2 method: ${residenceObjectID}`)
+          throw new Error(
+            `No devices found for residenceID: ${residenceID} or residenceIDV2 method: ${residenceObjectID}`
+          )
         }
         Leviton.subscribe(login, devices, this.subscriptionCallback.bind(this), this)
       }

--- a/index.js
+++ b/index.js
@@ -68,20 +68,35 @@ class LevitonDecoraSmartPlatform {
       token,
     })
     const accountID = permissions[0].residentialAccountId
-    const { primaryResidenceId: residenceID } = await Leviton.getResidentialAccounts({
+    var { primaryResidenceId: residenceID, id: residenceObjectID } = await Leviton.getResidentialAccounts({
       accountID,
       token,
     })
-    const devices = await Leviton.getResidenceIotSwitches({
+
+    var devices = await Leviton.getResidenceIotSwitches({
       residenceID,
       token,
     })
 
     try {
       if (!Array.isArray(devices) || devices.length < 1) {
-        throw new Error(`No devices found for residenceID: ${residenceID}`)
+        console.log('No devices found for primary residence id. Trying residence v2')
+        const accountsV2Response = await Leviton.getResidentialAccountsV2({
+          residenceObjectID,
+          token,
+        })
+
+        residenceID = accountsV2Response[0].id
+        devices = await Leviton.getResidenceIotSwitches({
+          residenceID,
+          token,
+        })
+
+        if (!Array.isArray(devices) || devices.length < 1) {
+          throw new Error(`No devices found for residenceID: ${residenceID} or residenceIDV2 method: ${residenceObjectID}`)
+        }
+        Leviton.subscribe(login, devices, this.subscriptionCallback.bind(this), this)
       }
-      Leviton.subscribe(login, devices, this.subscriptionCallback.bind(this), this)
     } catch (e) {
       this.log('Error subscribing devices to websocket updates:', e)
     }


### PR DESCRIPTION
Update fetch method for iotSwitches to try to use the latest leviton API method of getting the user's residenceID.

See https://github.com/tabrindle/homebridge-leviton/issues/6#issuecomment-1128263800 for details. 